### PR TITLE
Support operations on frozensets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Pandas Sets: Set-oriented Operations in Pandas
 
-If you store standard Python `set`s in your `Series` or `DataFrame` objects, you'll find this useful.
+If you store standard Python `set`s or `frozenset`s in your `Series` or `DataFrame` objects, you'll find this useful.
 
 The `pandas_sets` package adds a `.set` accessor to any pandas `Series` object;
 it's like `.dt` for `datetime` or `.str` for `string`, but for [`set`](https://docs.python.org/3.7/library/stdtypes.html#set).
 
-It exposes all public methods available in the standard [`set`](https://docs.python.org/3.7/library/stdtypes.html#set). 
+It exposes all public methods available in the standard [`set`](https://docs.python.org/3.7/library/stdtypes.html#set).
 
 ## Installation
 ```bash
@@ -24,7 +24,7 @@ import pandas as pd
 df = pd.DataFrame({'post': [1, 2, 3, 4],
                     'tags': [{'python', 'pandas'}, {'philosophy', 'strategy'}, {'scikit-learn'}, {'pandas'}]
                    })
-                   
+
 pandas_posts = df[df.tags.set.contains('pandas')]
 
 pandas_posts.tags.set.add('data')

--- a/pandas_sets/sets.py
+++ b/pandas_sets/sets.py
@@ -10,7 +10,7 @@ copy = strings.copy
 
 
 def is_set_type(data):
-    return isinstance(data, set)
+    return isinstance(data, set) or isinstance(data, frozenset)
 
 
 def _map(*args, **kwargs):
@@ -208,10 +208,10 @@ class SetMethods(NoNewAttributesMixin):
                 and data.map(is_list_like).all()
                 and data.map(is_set_type).all()
         ):
-            raise AttributeError("Can only use .set accessor with object dtype."
-                                 "All values must be of `set` type too."
-                                 "Null values` are rejected. "
-                                 "Better use something like fillna([]) before.")
+            raise AttributeError("Can only use .set accessor with object dtype. "
+                                 "All values must be of `set` or `frozenset` type too. "
+                                 "Null values` are rejected, "
+                                 "so use something like fillna([]) before.")
 
     def len(self):
         # TODO make it use _no_args_wrapper like the StringMethods equivalent does

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -25,6 +25,14 @@ class APITestCase(TestCase):
         })
 
     @property
+    def frozenset_no_na_with_empty(self):
+        return Series({
+            'a': frozenset([1]),
+            'b': frozenset([3, 4, 5]),
+            'c': frozenset([])
+        })
+
+    @property
     def simple_case_no_na_without_empty(self):
         return Series({
             'a': set([1]),
@@ -85,3 +93,10 @@ class APITestCase(TestCase):
                                    'a': 0,
                                    'b': 2
                                }))
+
+    def test_frozensets_are_allowed(self):
+        tm.assert_series_equal(self.frozenset_no_na_with_empty.set.contains(1), Series({
+            'a': True,
+            'b': False,
+            'c': False
+        }))


### PR DESCRIPTION
I'm using `frozenset` in my dataframes rather than `set` because otherwise pandas operations such as `unique` don't work. Modify the `is_set_type` method to consider `frozenset` a set type.